### PR TITLE
Adding texinfo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.texinfo?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=140&branchName=master)
+
+# texinfo
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+plan_name : "texinfo"

--- a/controls/texinfo_test.rb
+++ b/controls/texinfo_test.rb
@@ -1,0 +1,87 @@
+title 'Tests to confirm texinfo works as expected'
+
+plan_name = input('plan_name', value: 'texinfo')
+plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
+hab_path = input('hab_path', value: 'hab')
+
+control 'core-plans-texinfo' do
+  impact 1.0
+  title 'Ensure texinfo works'
+  desc '
+  There are several binaries in the texinfo package.  We check that the help and version commands
+  work as expected for a couple of these:
+
+    $ info --version
+    info --version
+    info (GNU texinfo) 6.6
+
+    Copyright (C) 2019 Free Software Foundation, Inc.
+    ...
+
+    $ info --help
+    Usage: info [OPTION]... [MENU-ITEM...]
+
+    Read documentation in Info format.
+    ...
+
+    $ install-info --version
+    install-info (GNU texinfo) 6.6
+
+    Copyright (C) 2019 Free Software Foundation, Inc.
+    ...
+
+    $ install-info --help
+    Usage: install-info [OPTION]... [INFO-FILE [DIR-FILE]]
+    ...
+
+  '
+  texinfo_pkg_ident = command("#{hab_path} pkg path #{plan_ident}")
+  describe texinfo_pkg_ident do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+  texinfo_pkg_ident = texinfo_pkg_ident.stdout.strip
+  version_string = texinfo_pkg_ident.split('/')[5]
+
+  describe command("#{texinfo_pkg_ident}/bin/info --version") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /info \(GNU texinfo\) #{version_string}/ }
+    its('stderr') { should be_empty }
+  end
+
+  describe command("#{texinfo_pkg_ident}/bin/info --help") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /Usage: info/ }
+    its('stderr') { should be_empty }
+  end
+
+  describe command("#{texinfo_pkg_ident}/bin/install-info --version") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /install-info \(GNU texinfo\) #{version_string}/ }
+    its('stderr') { should be_empty }
+  end
+
+  describe command("#{texinfo_pkg_ident}/bin/install-info --help") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /Usage: install-info/ }
+    its('stderr') { should be_empty }
+  end
+
+  describe command("#{texinfo_pkg_ident}/bin/makeinfo --version") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /texi2any \(GNU texinfo\) #{version_string}/ }
+    its('stderr') { should be_empty }
+  end
+
+  describe command("#{texinfo_pkg_ident}/bin/makeinfo --help") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /Usage: makeinfo/ }
+    its('stderr') { should be_empty }
+  end
+end

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,7 +1,7 @@
-name: {{plan_name}}
-title: Habitat Core Plan {{plan_name}}
+name: texinfo
+title: Habitat Core Plan texinfo
 maintainer: humans@habitat.sh
-summary: InSpec controls for testing Habitat Core Plan {{plan_name}}
+summary: InSpec controls for testing Habitat Core Plan texinfo
 copyright: humans@habitat.sh
 copyright_email: humans@habitat.sh
 version: 0.1.0

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,47 @@
+pkg_name=texinfo
+pkg_origin=core
+pkg_version=6.6
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="\
+Texinfo is the official documentation format of the GNU project. It was \
+invented by Richard Stallman and Bob Chassell many years ago, loosely based on \
+Brian Reid's Scribe and other formatting languages of the time. It is used by \
+many non-GNU projects as well.\
+"
+pkg_upstream_url="http://www.gnu.org/software/texinfo/"
+pkg_license=('GPL-3.0-or-later')
+pkg_source="http://ftp.gnu.org/gnu/$pkg_name/${pkg_name}-${pkg_version}.tar.xz"
+pkg_shasum="9bb9ca00da53f26a7e5725eee49689cd4a1e18d25d5b061ac8b2053018d93d66"
+pkg_deps=(
+  core/glibc
+  core/ncurses
+  core/perl
+)
+pkg_build_deps=(
+  core/patch
+  core/make
+  core/gcc
+  core/sed
+)
+pkg_bin_dirs=(bin)
+
+do_check() {
+  make check
+}
+
+
+# ----------------------------------------------------------------------------
+# **NOTICE:** What follows are implementation details required for building a
+# first-pass, "stage1" toolchain and environment. It is only used when running
+# in a "stage1" Studio and can be safely ignored by almost everyone. Having
+# said that, it performs a vital bootstrapping process and cannot be removed or
+# significantly altered. Thank you!
+# ----------------------------------------------------------------------------
+if [[ "$STUDIO_TYPE" = "stage1" ]]; then
+  pkg_build_deps=(
+    core/gcc
+    core/sed
+    core/make
+    core/patch
+  )
+fi

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,0 +1,4 @@
+@test "texinfo displays help" {
+  run hab pkg exec $TEST_PKG_IDENT info --help
+  [ "$status" -eq 0 ]
+}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
Migration from core plans plus inspec tests:

```
Profile: Habitat Core Plan texinfo (texinfo)
Version: 0.1.0
Target:  docker://5baffa36ad3c7470b190af8188a055a17a7848fe5aea643c893be7c54ba21193

  ✔  core-plans-texinfo: Ensure texinfo works
     ✔  Command: `hab pkg path habskp/texinfo` exit_status is expected to eq 0
     ✔  Command: `hab pkg path habskp/texinfo` stdout is expected not to be empty
     ✔  Command: `/hab/pkgs/habskp/texinfo/6.6/20200612150700/bin/info --version` exit_status is expected to eq 0
     ✔  Command: `/hab/pkgs/habskp/texinfo/6.6/20200612150700/bin/info --version` stdout is expected not to be empty
     ✔  Command: `/hab/pkgs/habskp/texinfo/6.6/20200612150700/bin/info --version` stdout is expected to match /info \(GNU texinfo\) 6.6/
     ✔  Command: `/hab/pkgs/habskp/texinfo/6.6/20200612150700/bin/info --version` stderr is expected to be empty
     ✔  Command: `/hab/pkgs/habskp/texinfo/6.6/20200612150700/bin/info --help` exit_status is expected to eq 0
     ✔  Command: `/hab/pkgs/habskp/texinfo/6.6/20200612150700/bin/info --help` stdout is expected not to be empty
     ✔  Command: `/hab/pkgs/habskp/texinfo/6.6/20200612150700/bin/info --help` stdout is expected to match /Usage: info/
     ✔  Command: `/hab/pkgs/habskp/texinfo/6.6/20200612150700/bin/info --help` stderr is expected to be empty
     ✔  Command: `/hab/pkgs/habskp/texinfo/6.6/20200612150700/bin/install-info --version` exit_status is expected to eq 0
     ✔  Command: `/hab/pkgs/habskp/texinfo/6.6/20200612150700/bin/install-info --version` stdout is expected not to be empty
     ✔  Command: `/hab/pkgs/habskp/texinfo/6.6/20200612150700/bin/install-info --version` stdout is expected to match /install-info \(GNU texinfo\) 6.6/
     ✔  Command: `/hab/pkgs/habskp/texinfo/6.6/20200612150700/bin/install-info --version` stderr is expected to be empty
     ✔  Command: `/hab/pkgs/habskp/texinfo/6.6/20200612150700/bin/install-info --help` exit_status is expected to eq 0
     ✔  Command: `/hab/pkgs/habskp/texinfo/6.6/20200612150700/bin/install-info --help` stdout is expected not to be empty
     ✔  Command: `/hab/pkgs/habskp/texinfo/6.6/20200612150700/bin/install-info --help` stdout is expected to match /Usage: install-info/
     ✔  Command: `/hab/pkgs/habskp/texinfo/6.6/20200612150700/bin/install-info --help` stderr is expected to be empty
     ✔  Command: `/hab/pkgs/habskp/texinfo/6.6/20200612150700/bin/makeinfo --version` exit_status is expected to eq 0
     ✔  Command: `/hab/pkgs/habskp/texinfo/6.6/20200612150700/bin/makeinfo --version` stdout is expected not to be empty
     ✔  Command: `/hab/pkgs/habskp/texinfo/6.6/20200612150700/bin/makeinfo --version` stdout is expected to match /texi2any \(GNU texinfo\) 6.6/
     ✔  Command: `/hab/pkgs/habskp/texinfo/6.6/20200612150700/bin/makeinfo --version` stderr is expected to be empty
     ✔  Command: `/hab/pkgs/habskp/texinfo/6.6/20200612150700/bin/makeinfo --help` exit_status is expected to eq 0
     ✔  Command: `/hab/pkgs/habskp/texinfo/6.6/20200612150700/bin/makeinfo --help` stdout is expected not to be empty
     ✔  Command: `/hab/pkgs/habskp/texinfo/6.6/20200612150700/bin/makeinfo --help` stdout is expected to match /Usage: makeinfo/
     ✔  Command: `/hab/pkgs/habskp/texinfo/6.6/20200612150700/bin/makeinfo --help` stderr is expected to be empty


Profile Summary: 1 successful control, 0 control failures, 0 controls skipped
Test Summary: 26 successful, 0 failures, 0 skipped
```

﻿Signed-off-by: Stuart Paterson <spaterson@chef.io>
